### PR TITLE
Fixed typo in Instructions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Then just include this module to your project and add to main Angular app depend
 ```javascript
 require('angular-promise-polyfill');
 
-let app = angular.module('myApp', [promisePolyfill, ...]);
+let app = angular.module('myApp', ['angular-promise-polyfill', ...]);
 
 // Now you can use Promise anywhere
 


### PR DESCRIPTION
While attempting to use this module, I noticed I had issues when I used `promisePolyfill` and my app would crash. Changing it to use the name of the module that is being required in fixed the issue.